### PR TITLE
Fix Error: either install disk or diskSelector should be defined #34

### DIFF
--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -34,7 +34,12 @@ machine:
     image: {{ . }}
     {{- end }}
     {{- (include "talm.discovered.disks_info" .) | nindent 4 }}
-    disk: {{ include "talm.discovered.system_disk_name" . | quote }}
+    {{- $disk := include "talm.discovered.system_disk_name" . }}
+    {{- if eq $disk "" }}
+    disk: /dev/sda
+    {{- else }}
+    disk: {{ $disk | quote }}
+    {{- end }}
   network:
     hostname: {{ include "talm.discovered.hostname" . | quote }}
     nameservers: {{ include "talm.discovered.default_resolvers" . }}

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -7,7 +7,12 @@ machine:
         {{- toYaml .Values.advertisedSubnets | nindent 8 }}
   install:
     {{- (include "talm.discovered.disks_info" .) | nindent 4 }}
-    disk: {{ include "talm.discovered.system_disk_name" . | quote }}
+    {{- $disk := include "talm.discovered.system_disk_name" . }}
+    {{- if eq $disk "" }}
+    disk: /dev/sda
+    {{- else }}
+    disk: {{ $disk | quote }}
+    {{- end }}
   network:
     hostname: {{ include "talm.discovered.hostname" . | quote }}
     nameservers: {{ include "talm.discovered.default_resolvers" . }}

--- a/pkg/generated/presets.go
+++ b/pkg/generated/presets.go
@@ -64,7 +64,12 @@ machine:
     image: {{ . }}
     {{- end }}
     {{- (include "talm.discovered.disks_info" .) | nindent 4 }}
-    disk: {{ include "talm.discovered.system_disk_name" . | quote }}
+    disk: {{- $disk := include "talm.discovered.system_disk_name" . }}
+    {{- if eq $disk "" }}
+    /dev/sda
+    {{- else }}
+    {{ $disk | quote }}
+    {{- end }}
   network:
     hostname: {{ include "talm.discovered.hostname" . | quote }}
     nameservers: {{ include "talm.discovered.default_resolvers" . }}

--- a/pkg/generated/presets.go
+++ b/pkg/generated/presets.go
@@ -64,11 +64,11 @@ machine:
     image: {{ . }}
     {{- end }}
     {{- (include "talm.discovered.disks_info" .) | nindent 4 }}
-    disk: {{- $disk := include "talm.discovered.system_disk_name" . }}
+    {{- $disk := include "talm.discovered.system_disk_name" . }}
     {{- if eq $disk "" }}
-    /dev/sda
+    disk: /dev/sda
     {{- else }}
-    {{ $disk | quote }}
+    disk: {{ $disk | quote }}
     {{- end }}
   network:
     hostname: {{ include "talm.discovered.hostname" . | quote }}
@@ -180,7 +180,12 @@ machine:
         {{- toYaml .Values.advertisedSubnets | nindent 8 }}
   install:
     {{- (include "talm.discovered.disks_info" .) | nindent 4 }}
-    disk: {{ include "talm.discovered.system_disk_name" . | quote }}
+    {{- $disk := include "talm.discovered.system_disk_name" . }}
+    {{- if eq $disk "" }}
+    disk: /dev/sda
+    {{- else }}
+    disk: {{ $disk | quote }}
+    {{- end }}
   network:
     hostname: {{ include "talm.discovered.hostname" . | quote }}
     nameservers: {{ include "talm.discovered.default_resolvers" . }}


### PR DESCRIPTION
fix: Default to /dev/sda if no disk is found

Updated the disk selection logic to use /dev/sda as the default value when no disk is discovered. This ensures that the installation process has a fallback option, improving reliability in environments where disks may not be detected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the disk configuration process by automatically falling back to a default disk when none is detected, ensuring consistent and robust system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->