### PR TITLE
Fix filter to show QEMU disks

### DIFF
--- a/charts/talm/templates/_helpers.tpl
+++ b/charts/talm/templates/_helpers.tpl
@@ -5,7 +5,7 @@
 {{- else }}
 {{- $disk := "/dev/sda" }}
 {{- range (lookup "disks" "" "").items }}
-{{- if .spec.wwid }}
+{{- if or .spec.wwid .spec.model }}
 {{- $disk = .spec.dev_path }}
 {{- break }}
 {{- end }}
@@ -30,7 +30,7 @@
 {{- define "talm.discovered.disks_info" }}
 # -- Discovered disks:
 {{- range (lookup "disks" "" "").items }}
-{{- if .spec.wwid }}
+{{- if or .spec.wwid .spec.model }}
 # {{ .spec.dev_path }}:
 #    model: {{ .spec.model }}
 #    serial: {{ .spec.serial }}

--- a/pkg/generated/presets.go
+++ b/pkg/generated/presets.go
@@ -235,7 +235,7 @@ description: A library Talm chart for Talos Linux
 {{- else }}
 {{- $disk := "/dev/sda" }}
 {{- range (lookup "disks" "" "").items }}
-{{- if .spec.wwid }}
+{{- if or .spec.wwid .spec.model }}
 {{- $disk = .spec.dev_path }}
 {{- break }}
 {{- end }}
@@ -260,7 +260,7 @@ description: A library Talm chart for Talos Linux
 {{- define "talm.discovered.disks_info" }}
 # -- Discovered disks:
 {{- range (lookup "disks" "" "").items }}
-{{- if .spec.wwid }}
+{{- if or .spec.wwid .spec.model }}
 # {{ .spec.dev_path }}:
 #    model: {{ .spec.model }}
 #    serial: {{ .spec.serial }}


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved disk discovery logic to now recognize disks identified by either a unique identifier or a model.
  - Standardized the disk detection process, ensuring consistent behavior across various system checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->