### PR TITLE
Add mirror.gcr.io as default mirror for docker.io

### DIFF
--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -20,6 +20,11 @@ machine:
         - usermode_helper=disabled
     - name: zfs
     - name: spl
+  registries:
+    mirrors:
+      docker.io:
+        endpoints:
+        - https://mirror.gcr.io
   files:
   - content: |
       [plugins]

--- a/pkg/generated/presets.go
+++ b/pkg/generated/presets.go
@@ -50,6 +50,11 @@ machine:
         - usermode_helper=disabled
     - name: zfs
     - name: spl
+  registries:
+    mirrors:
+      docker.io:
+        endpoints:
+        - https://mirror.gcr.io
   files:
   - content: |
       [plugins]


### PR DESCRIPTION

related issues:
- https://github.com/cozystack/talm/pull/48
- https://github.com/cozystack/website/pull/154
- https://github.com/cozystack/cozystack/pull/782


## Summary by CodeRabbit

- **New Features**
	- Introduced a new container registry configuration option that allows users to specify an alternate mirror endpoint for Docker images, enhancing image retrieval possibilities without altering existing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->