### PR TITLE
Switch back to use interface names by default

### DIFF
--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -40,8 +40,7 @@ machine:
     nameservers: {{ include "talm.discovered.default_resolvers" . }}
     {{- (include "talm.discovered.physical_links_info" .) | nindent 4 }}
     interfaces:
-    - deviceSelector:
-        {{- include "talm.discovered.default_link_selector_by_gateway" . | nindent 8 }}
+    - interface: {{ include "talm.discovered.default_link_name_by_gateway" . }}
       addresses: {{ include "talm.discovered.default_addresses_by_gateway" . }}
       routes:
         - network: 0.0.0.0/0

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -13,8 +13,7 @@ machine:
     nameservers: {{ include "talm.discovered.default_resolvers" . }}
     {{- (include "talm.discovered.physical_links_info" .) | nindent 4 }}
     interfaces:
-    - deviceSelector:
-        {{- include "talm.discovered.default_link_selector_by_gateway" . | nindent 8 }}
+    - interface: {{ include "talm.discovered.default_link_name_by_gateway" . }}
       addresses: {{ include "talm.discovered.default_addresses_by_gateway" . }}
       routes:
         - network: 0.0.0.0/0

--- a/charts/talm/templates/_helpers.tpl
+++ b/charts/talm/templates/_helpers.tpl
@@ -70,8 +70,7 @@
 # -- Discovered interfaces:
 {{- range (lookup "links" "" "").items }}
 {{- if and .spec.busPath (regexMatch "^(eno|eth|enp|enx|ens)" .metadata.id) }}
-# enx{{ .spec.hardwareAddr | replace ":" "" }}:
-#   id: {{ .metadata.id }}
+# {{ .metadata.id }}:
 #   hardwareAddr:{{ .spec.hardwareAddr }}
 #   busPath: {{ .spec.busPath }}
 #   driver: {{ .spec.driver }}

--- a/pkg/generated/presets.go
+++ b/pkg/generated/presets.go
@@ -70,8 +70,7 @@ machine:
     nameservers: {{ include "talm.discovered.default_resolvers" . }}
     {{- (include "talm.discovered.physical_links_info" .) | nindent 4 }}
     interfaces:
-    - deviceSelector:
-        {{- include "talm.discovered.default_link_selector_by_gateway" . | nindent 8 }}
+    - interface: {{ include "talm.discovered.default_link_name_by_gateway" . }}
       addresses: {{ include "talm.discovered.default_addresses_by_gateway" . }}
       routes:
         - network: 0.0.0.0/0
@@ -181,8 +180,7 @@ machine:
     nameservers: {{ include "talm.discovered.default_resolvers" . }}
     {{- (include "talm.discovered.physical_links_info" .) | nindent 4 }}
     interfaces:
-    - deviceSelector:
-        {{- include "talm.discovered.default_link_selector_by_gateway" . | nindent 8 }}
+    - interface: {{ include "talm.discovered.default_link_name_by_gateway" . }}
       addresses: {{ include "talm.discovered.default_addresses_by_gateway" . }}
       routes:
         - network: 0.0.0.0/0
@@ -300,8 +298,7 @@ description: A library Talm chart for Talos Linux
 # -- Discovered interfaces:
 {{- range (lookup "links" "" "").items }}
 {{- if and .spec.busPath (regexMatch "^(eno|eth|enp|enx|ens)" .metadata.id) }}
-# enx{{ .spec.hardwareAddr | replace ":" "" }}:
-#   id: {{ .metadata.id }}
+# {{ .metadata.id }}:
 #   hardwareAddr:{{ .spec.hardwareAddr }}
 #   busPath: {{ .spec.busPath }}
 #   driver: {{ .spec.driver }}


### PR DESCRIPTION
fixes https://github.com/cozystack/talm/issues/27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined network interface configuration by replacing the previous selection mechanism with a direct assignment approach while preserving existing address and route settings.
  - Simplified interface detail annotations to provide a cleaner, less cluttered presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->