### PR TITLE
Reuse networking configuration from the node if exists

### DIFF
--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -47,15 +47,20 @@ machine:
     nameservers: {{ include "talm.discovered.default_resolvers" . }}
     {{- (include "talm.discovered.physical_links_info" .) | nindent 4 }}
     interfaces:
+    {{- $existingInterfacesConfiguration := include "talm.discovered.existing_interfaces_configuration" . }}
+    {{- if $existingInterfacesConfiguration }}
+    {{- $existingInterfacesConfiguration | nindent 4 }}
+    {{- else }}
     - interface: {{ include "talm.discovered.default_link_name_by_gateway" . }}
       addresses: {{ include "talm.discovered.default_addresses_by_gateway" . }}
       routes:
         - network: 0.0.0.0/0
           gateway: {{ include "talm.discovered.default_gateway" . }}
-      {{- if eq .MachineType "controlplane" }}{{ with .Values.floatingIP }}
+      {{- if and .Values.floatingIP (eq .MachineType "controlplane") }}
       vip:
-        ip: {{ . }}
-      {{- end }}{{ end }}
+        ip: {{ .Values.floatingIP }}
+      {{- end }}
+    {{- end }}
 
 cluster:
   network:

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -13,15 +13,20 @@ machine:
     nameservers: {{ include "talm.discovered.default_resolvers" . }}
     {{- (include "talm.discovered.physical_links_info" .) | nindent 4 }}
     interfaces:
+    {{- $existingInterfacesConfiguration := include "talm.discovered.existing_interfaces_configuration" . }}
+    {{- if $existingInterfacesConfiguration }}
+    {{- $existingInterfacesConfiguration | nindent 4 }}
+    {{- else }}
     - interface: {{ include "talm.discovered.default_link_name_by_gateway" . }}
       addresses: {{ include "talm.discovered.default_addresses_by_gateway" . }}
       routes:
         - network: 0.0.0.0/0
           gateway: {{ include "talm.discovered.default_gateway" . }}
-      {{- with .Values.floatingIP }}
+      {{- if and .Values.floatingIP (eq .MachineType "controlplane") }}
       vip:
-        ip: {{ . }}
+        ip: {{ .Values.floatingIP }}
       {{- end }}
+    {{- end }}
 
 cluster:
   network:

--- a/charts/talm/templates/_helpers.tpl
+++ b/charts/talm/templates/_helpers.tpl
@@ -141,3 +141,9 @@ busPath: {{ .spec.busPath }}
 {{- toJson .spec.dnsServers }}
 {{- end }}
 {{- end }}
+
+{{- define "talm.discovered.existing_interfaces_configuration" }}
+{{- with (lookup "machineconfig" "" "v1alpha1") }}
+{{ toYaml .spec | fromYaml | dig "machine" "network" "interfaces" (list) | toYaml }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for using existing network interface configurations in machine setup, enabling more flexible network customization.
  - Introduced a helper to retrieve and render existing network interfaces from machine configuration resources.

- **Improvements**
  - Enhanced the logic for assigning floating IPs, now restricting VIP assignment to control plane machines only.
  - Simplified and clarified the conditional logic for interface configuration and floating IP assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->