### PR TITLE
Default the cpu manager policy to static

### DIFF
--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -11,6 +11,7 @@ machine:
       validSubnets:
         {{- toYaml .Values.advertisedSubnets | nindent 8 }}
     extraConfig:
+      cpuManagerPolicy: static
       maxPods: 512
   kernel:
     modules:

--- a/pkg/generated/presets.go
+++ b/pkg/generated/presets.go
@@ -41,6 +41,7 @@ machine:
       validSubnets:
         {{- toYaml .Values.advertisedSubnets | nindent 8 }}
     extraConfig:
+      cpuManagerPolicy: static
       maxPods: 512
   kernel:
     modules:


### PR DESCRIPTION
KubeVirt needs cpuManagerPolicy=static to run VMs with dedicated cores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The kubelet configuration for Talos machines now explicitly sets the CPU manager policy to "static".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->