### PR TITLE
Update Talos Linux image for Cozystack to v1.10.3

### DIFF
--- a/charts/cozystack/values.yaml
+++ b/charts/cozystack/values.yaml
@@ -1,7 +1,7 @@
 endpoint: "https://192.168.100.10:6443"
 clusterDomain: cozy.local
 floatingIP: 192.168.100.10
-image: "ghcr.io/cozystack/cozystack/talos:v1.9.5"
+image: "ghcr.io/cozystack/cozystack/talos:v1.10.3"
 podSubnets:
 - 10.244.0.0/16
 serviceSubnets:

--- a/pkg/generated/presets.go
+++ b/pkg/generated/presets.go
@@ -150,7 +150,7 @@ cluster:
 	"cozystack/values.yaml": `endpoint: "https://192.168.100.10:6443"
 clusterDomain: cozy.local
 floatingIP: 192.168.100.10
-image: "ghcr.io/cozystack/cozystack/talos:v1.9.5"
+image: "ghcr.io/cozystack/cozystack/talos:v1.10.3"
 podSubnets:
 - 10.244.0.0/16
 serviceSubnets:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Talos container image version used in deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->