### PR TITLE
[feature] Add templating for kubespan and allowSchedulingOnControlPla…

### DIFF
--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -56,6 +56,10 @@ machine:
     hostname: {{ include "talm.discovered.hostname" . | quote }}
     nameservers: {{ include "talm.discovered.default_resolvers" . }}
     {{- (include "talm.discovered.physical_links_info" .) | nindent 4 }}
+    {{- if eq .Values.kubespan true }}
+    kubespan:
+      enabled: true
+    {{- end }}
     interfaces:
     {{- $existingInterfacesConfiguration := include "talm.discovered.existing_interfaces_configuration" . }}
     {{- if $existingInterfacesConfiguration }}
@@ -85,7 +89,7 @@ cluster:
   controlPlane:
     endpoint: "{{ .Values.endpoint }}"
   {{- if eq .MachineType "controlplane" }}
-  allowSchedulingOnControlPlanes: true
+  allowSchedulingOnControlPlanes: {{ if eq .Values.allowSchedulingOnControlPlanes true }}true{{ else }}false{{ end }}
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0
@@ -108,7 +112,7 @@ cluster:
   proxy:
     disabled: true
   discovery:
-    enabled: false
+    enabled: {{ if eq .Values.kubespan true }}true{{ else }}false{{ end }}
   etcd:
     advertisedSubnets:
       {{- toYaml .Values.advertisedSubnets | nindent 6 }}

--- a/charts/cozystack/values.yaml
+++ b/charts/cozystack/values.yaml
@@ -10,3 +10,5 @@ advertisedSubnets:
 - 192.168.100.0/24
 oidcIssuerUrl: ""
 certSANs: []
+kubespan: false
+allowSchedulingOnControlPlanes: true

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,0 +1,120 @@
+{{- define "talos.config" }}
+machine:
+  {{- if eq .MachineType "controlplane" }}
+  nodeLabels:
+    node.kubernetes.io/exclude-from-external-load-balancers:
+      $patch: delete
+  {{- end }}
+  type: {{ .MachineType }}
+  kubelet:
+    nodeIP:
+      validSubnets:
+        {{- toYaml .Values.advertisedSubnets | nindent 8 }}
+    extraConfig:
+      cpuManagerPolicy: static
+      maxPods: 512
+  sysctls:
+    net.ipv4.neigh.default.gc_thresh1: "4096"
+    net.ipv4.neigh.default.gc_thresh2: "8192"
+    net.ipv4.neigh.default.gc_thresh3: "16384"
+  kernel:
+    modules:
+    - name: openvswitch
+    - name: drbd
+      parameters:
+        - usermode_helper=disabled
+    - name: zfs
+    - name: spl
+    - name: vfio_pci
+    - name: vfio_iommu_type1
+  certSANs:
+  - 127.0.0.1
+  {{- with .Values.certSANs }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  registries:
+    mirrors:
+      docker.io:
+        endpoints:
+        - https://mirror.gcr.io
+  files:
+  - content: |
+      [plugins]
+        [plugins."io.containerd.grpc.v1.cri"]
+          device_ownership_from_security_context = true
+        [plugins."io.containerd.cri.v1.runtime"]
+          device_ownership_from_security_context = true
+    path: /etc/cri/conf.d/20-customization.part
+    op: create
+  install:
+    {{- with .Values.image }}
+    image: {{ . }}
+    {{- end }}
+    {{- (include "talm.discovered.disks_info" .) | nindent 4 }}
+    disk: {{ include "talm.discovered.system_disk_name" . | quote }}
+  network:
+    hostname: {{ include "talm.discovered.hostname" . | quote }}
+    nameservers: {{ include "talm.discovered.default_resolvers" . }}
+    {{- (include "talm.discovered.physical_links_info" .) | nindent 4 }}
+    {{- if eq .Values.kubespan true }}
+    kubespan:
+      enabled: true
+    {{- end }}
+    interfaces:
+    {{- $existingInterfacesConfiguration := include "talm.discovered.existing_interfaces_configuration" . }}
+    {{- if $existingInterfacesConfiguration }}
+    {{- $existingInterfacesConfiguration | nindent 4 }}
+    {{- else }}
+    - interface: {{ include "talm.discovered.default_link_name_by_gateway" . }}
+      addresses: {{ include "talm.discovered.default_addresses_by_gateway" . }}
+      routes:
+        - network: 0.0.0.0/0
+          gateway: {{ include "talm.discovered.default_gateway" . }}
+      {{- if and .Values.floatingIP (eq .MachineType "controlplane") }}
+      vip:
+        ip: {{ .Values.floatingIP }}
+      {{- end }}
+    {{- end }}
+
+cluster:
+  network:
+    cni:
+      name: none
+    dnsDomain: {{ .Values.clusterDomain }}
+    podSubnets:
+      {{- toYaml .Values.podSubnets | nindent 6 }}
+    serviceSubnets:
+      {{- toYaml .Values.serviceSubnets | nindent 6 }}
+  clusterName: "{{ .Chart.Name }}"
+  controlPlane:
+    endpoint: "{{ .Values.endpoint }}"
+  {{- if eq .MachineType "controlplane" }}
+  allowSchedulingOnControlPlanes: {{ if eq .Values.allowSchedulingOnControlPlanes true }}true{{ else }}false{{ end }}
+  controllerManager:
+    extraArgs:
+      bind-address: 0.0.0.0
+  scheduler:
+    extraArgs:
+      bind-address: 0.0.0.0
+  apiServer:
+    {{- if and .Values.oidcIssuerUrl (ne .Values.oidcIssuerUrl "") }}
+    extraArgs:
+      oidc-issuer-url: "{{ .Values.oidcIssuerUrl }}"
+      oidc-client-id: "kubernetes"
+      oidc-username-claim: "preferred_username"
+      oidc-groups-claim: "groups"
+    {{- end }}
+    certSANs:
+    - 127.0.0.1
+    {{- with .Values.certSANs }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  proxy:
+    disabled: true
+  discovery:
+    enabled: {{ if eq .Values.kubespan true }}true{{ else }}false{{ end }}
+  etcd:
+    advertisedSubnets:
+      {{- toYaml .Values.advertisedSubnets | nindent 6 }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
[feature] Add templating for kubespan and allowSchedulingOnControlPlanes in values.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to enable or disable the Kubespan network feature through configuration settings.
  * Made the cluster discovery feature configurable based on the Kubespan setting.
  * Allow scheduling on control plane nodes to be toggled via configuration.
  * Introduced a new Helm template for dynamic machine configuration in Kubernetes clusters managed by Talos, supporting advanced network, kernel, and cluster settings.

* **Refactor**
  * Improved template logic to make multiple features configurable through Helm values instead of using fixed defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->