### PR TITLE
[feature] kubespan support and conditional scheduling options in values.yaml

### DIFF
--- a/charts/cozystack/templates/_helpers.tpl
+++ b/charts/cozystack/templates/_helpers.tpl
@@ -55,6 +55,10 @@ machine:
   network:
     hostname: {{ include "talm.discovered.hostname" . | quote }}
     nameservers: {{ include "talm.discovered.default_resolvers" . }}
+    {{- if eq .Values.kubespan true }}
+    kubespan:
+      enabled: true
+    {{- end }}
     {{- (include "talm.discovered.physical_links_info" .) | nindent 4 }}
     interfaces:
     {{- $existingInterfacesConfiguration := include "talm.discovered.existing_interfaces_configuration" . }}
@@ -85,7 +89,7 @@ cluster:
   controlPlane:
     endpoint: "{{ .Values.endpoint }}"
   {{- if eq .MachineType "controlplane" }}
-  allowSchedulingOnControlPlanes: true
+  allowSchedulingOnControlPlanes: {{ .Values.allowSchedulingOnControlPlanes }}
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0
@@ -108,7 +112,7 @@ cluster:
   proxy:
     disabled: true
   discovery:
-    enabled: false
+    enabled: {{ .Values.kubespan }}
   etcd:
     advertisedSubnets:
       {{- toYaml .Values.advertisedSubnets | nindent 6 }}

--- a/charts/cozystack/values.yaml
+++ b/charts/cozystack/values.yaml
@@ -10,3 +10,5 @@ advertisedSubnets:
 - 192.168.100.0/24
 oidcIssuerUrl: ""
 certSANs: []
+kubespan: false
+allowSchedulingOnControlPlanes: true

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -15,6 +15,10 @@ machine:
   network:
     hostname: {{ include "talm.discovered.hostname" . | quote }}
     nameservers: {{ include "talm.discovered.default_resolvers" . }}
+    {{- if eq .Values.kubespan true }}
+    kubespan:
+      enabled: true
+    {{- end }}
     {{- (include "talm.discovered.physical_links_info" .) | nindent 4 }}
     interfaces:
     {{- $existingInterfacesConfiguration := include "talm.discovered.existing_interfaces_configuration" . }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -6,3 +6,5 @@ serviceSubnets:
 advertisedSubnets:
 - 192.168.100.0/24
 certSANs: []
+kubespan: false
+allowSchedulingOnControlPlanes: true

--- a/pkg/generated/presets.go
+++ b/pkg/generated/presets.go
@@ -85,6 +85,10 @@ machine:
   network:
     hostname: {{ include "talm.discovered.hostname" . | quote }}
     nameservers: {{ include "talm.discovered.default_resolvers" . }}
+    {{- if eq .Values.kubespan true }}
+    kubespan:
+      enabled: true
+    {{- end }}
     {{- (include "talm.discovered.physical_links_info" .) | nindent 4 }}
     interfaces:
     {{- $existingInterfacesConfiguration := include "talm.discovered.existing_interfaces_configuration" . }}
@@ -115,7 +119,7 @@ cluster:
   controlPlane:
     endpoint: "{{ .Values.endpoint }}"
   {{- if eq .MachineType "controlplane" }}
-  allowSchedulingOnControlPlanes: true
+  allowSchedulingOnControlPlanes: {{ .Values.allowSchedulingOnControlPlanes }}
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0
@@ -138,7 +142,7 @@ cluster:
   proxy:
     disabled: true
   discovery:
-    enabled: false
+    enabled: {{ .Values.kubespan }}
   etcd:
     advertisedSubnets:
       {{- toYaml .Values.advertisedSubnets | nindent 6 }}
@@ -163,7 +167,8 @@ advertisedSubnets:
 - 192.168.100.0/24
 oidcIssuerUrl: ""
 certSANs: []
-`,
+kubespan: false
+allowSchedulingOnControlPlanes: true`,
 	"generic/Chart.yaml": `apiVersion: v2
 name: %s
 type: application
@@ -208,6 +213,10 @@ machine:
   network:
     hostname: {{ include "talm.discovered.hostname" . | quote }}
     nameservers: {{ include "talm.discovered.default_resolvers" . }}
+    {{- if eq .Values.kubespan true }}
+    kubespan:
+      enabled: true
+    {{- end }}
     {{- (include "talm.discovered.physical_links_info" .) | nindent 4 }}
     interfaces:
     {{- $existingInterfacesConfiguration := include "talm.discovered.existing_interfaces_configuration" . }}
@@ -260,7 +269,8 @@ serviceSubnets:
 advertisedSubnets:
 - 192.168.100.0/24
 certSANs: []
-`,
+kubespan: false
+allowSchedulingOnControlPlanes: true`,
 	"talm/Chart.yaml": `apiVersion: v2
 type: library
 name: %s


### PR DESCRIPTION
[feature] kubespan support and conditional scheduling options in values.yaml

Corrected attempt from #69 to add kubespan templating values and allowschedulingoncontrolplanes options

I noticed that discovery is set to false by default in talm template, but I confuse that talos documentation mention to set it to true by default: https://www.talos.dev/v1.10/talos-guides/network/kubespan/

"In order to enable KubeSpan on an existing cluster, enable kubespan and discovery settings in the machine config for each machine in the cluster (discovery is enabled by default):"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration options to enable the "kubespan" feature and control scheduling on control plane nodes in CozyStack and Generic charts.
* **Chores**
  * Updated default configuration files to include new settings for enhanced customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->