### PR TITLE
Makes the preset flag mandatory

### DIFF
--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -210,6 +210,7 @@ func init() {
 	initCmd.Flags().BoolVarP(&initCmdFlags.update, "update", "u", false, "update Talm library chart")
 
 	addCommand(initCmd)
+	initCmd.MarkFlagRequired("preset")
 }
 
 func isValidPreset(preset string) bool {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The init command now requires an explicit --preset flag. The command will fail early if --preset is not provided.
  * Validation and subsequent setup run only after a preset is supplied, ensuring clearer, more intentional initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->